### PR TITLE
Fix for #64, video player no longer overlaps the page context menus

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -1280,7 +1280,7 @@ path{
         position: sticky;
         top: -1px; // allows to handle the sticky effect
         bottom: 0px;
-        z-index: 100;
+        z-index: 5;
         #media-container {
           pointer-events: all;
           box-shadow: none;


### PR DESCRIPTION
z-index value for the .active class was change from 100 to 5 in `page.vue`, as a result video player not longer overlaps the page context menus

